### PR TITLE
Fix player search whitespace handling

### DIFF
--- a/app/MCP/Tools/Data/UnifiedDataTool.php
+++ b/app/MCP/Tools/Data/UnifiedDataTool.php
@@ -163,7 +163,8 @@ class UnifiedDataTool implements ToolInterface
         /** @var SleeperSdk $sdk */
         $sdk = LaravelApp::make(SleeperSdk::class);
         $sport = $arguments['sport'] ?? 'nfl';
-        $query = (string) $arguments['query'];
+        // Trim the query to avoid mismatches caused by leading/trailing spaces
+        $query = trim((string) $arguments['query']);
         $position = $arguments['position'] ?? null;
         $team = $arguments['team'] ?? null;
 

--- a/tests/Unit/UnifiedDataToolTest.php
+++ b/tests/Unit/UnifiedDataToolTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\MCP\Tools\Data\UnifiedDataTool;
+use App\Services\SleeperSdk;
+use Illuminate\Support\Facades\App;
+use Mockery;
+
+afterEach(function () {
+    Mockery::close();
+});
+
+test('player search ignores surrounding whitespace', function () {
+    $mockSdk = Mockery::mock(SleeperSdk::class);
+    $mockSdk->shouldReceive('getPlayersCatalog')
+        ->once()
+        ->with('nfl')
+        ->andReturn([
+            '1' => ['full_name' => 'Tom Brady', 'position' => 'QB', 'team' => 'TB'],
+        ]);
+
+    App::instance(SleeperSdk::class, $mockSdk);
+
+    $tool = new UnifiedDataTool;
+
+    $result = $tool->execute([
+        'data_type' => 'players',
+        'query' => ' Tom Brady ',
+    ]);
+
+    expect($result['count'])->toBe(1)
+        ->and($result['results'][0]['name'])->toBe('Tom Brady');
+});


### PR DESCRIPTION
## Summary
- trim fantasy data player search queries to avoid mismatches
- add unit test ensuring player lookup ignores surrounding whitespace

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae25128a8883249287e9968267953c