### PR TITLE
Include player details with all MCP tool player IDs

### DIFF
--- a/app/MCP/Tools/Lineup/UnifiedLineupTool.php
+++ b/app/MCP/Tools/Lineup/UnifiedLineupTool.php
@@ -104,6 +104,7 @@ class UnifiedLineupTool implements ToolInterface
             $playersByPosition[$pos][] = [
                 'player_id' => $pid,
                 'name' => $meta['full_name'] ?? trim(($meta['first_name'] ?? '').' '.($meta['last_name'] ?? '')),
+                'position' => $pos,
                 'team' => $meta['team'] ?? null,
                 'projected_points' => (float) (($projections[$pid]['pts_half_ppr'] ?? $projections[$pid]['pts_ppr'] ?? $projections[$pid]['pts_std'] ?? 0)),
             ];

--- a/app/MCP/Tools/Recommendations/UnifiedRecommendationsTool.php
+++ b/app/MCP/Tools/Recommendations/UnifiedRecommendationsTool.php
@@ -444,6 +444,7 @@ class UnifiedRecommendationsTool implements ToolInterface
 
             $candidates[] = [
                 'player_id' => $pid,
+                'name' => $meta['full_name'] ?? trim(($meta['first_name'] ?? '') . ' ' . ($meta['last_name'] ?? '')),
                 'projected_points' => $proj,
                 'trend_count' => (int) ($entry['count'] ?? 0),
                 'score' => $score,
@@ -496,16 +497,34 @@ class UnifiedRecommendationsTool implements ToolInterface
         $sendingValue = 0;
         $receivingValue = 0;
 
+        $sending = [];
         foreach ($offer['sending'] as $pid) {
+            $pid = (string) $pid;
             $proj = (float) (($projections[$pid]['pts_half_ppr'] ?? $projections[$pid]['pts_ppr'] ?? $projections[$pid]['pts_std'] ?? 0));
             $adpVal = $adpIndex[$pid] ?? 999.0;
             $sendingValue += ($proj * 0.7) + (1000 - $adpVal) * 0.3; // Weighted combination
+            $meta = $catalog[$pid] ?? [];
+            $sending[] = [
+                'player_id' => $pid,
+                'name' => $meta['full_name'] ?? trim(($meta['first_name'] ?? '') . ' ' . ($meta['last_name'] ?? '')),
+                'position' => $meta['position'] ?? null,
+                'team' => $meta['team'] ?? null,
+            ];
         }
 
+        $receiving = [];
         foreach ($offer['receiving'] as $pid) {
+            $pid = (string) $pid;
             $proj = (float) (($projections[$pid]['pts_half_ppr'] ?? $projections[$pid]['pts_ppr'] ?? $projections[$pid]['pts_std'] ?? 0));
             $adpVal = $adpIndex[$pid] ?? 999.0;
             $receivingValue += ($proj * 0.7) + (1000 - $adpVal) * 0.3;
+            $meta = $catalog[$pid] ?? [];
+            $receiving[] = [
+                'player_id' => $pid,
+                'name' => $meta['full_name'] ?? trim(($meta['first_name'] ?? '') . ' ' . ($meta['last_name'] ?? '')),
+                'position' => $meta['position'] ?? null,
+                'team' => $meta['team'] ?? null,
+            ];
         }
 
         $tradeValue = $receivingValue - $sendingValue;
@@ -518,8 +537,8 @@ class UnifiedRecommendationsTool implements ToolInterface
                 'recommendation' => $recommendation,
                 'sending_value' => $sendingValue,
                 'receiving_value' => $receivingValue,
-                'sending_players' => $offer['sending'],
-                'receiving_players' => $offer['receiving'],
+                'sending_players' => $sending,
+                'receiving_players' => $receiving,
             ],
             'league_id' => $leagueId,
             'season' => $season,

--- a/app/MCP/Tools/Sleeper/AdpGetTool.php
+++ b/app/MCP/Tools/Sleeper/AdpGetTool.php
@@ -4,6 +4,7 @@ namespace App\MCP\Tools\Sleeper;
 
 use App\Services\EspnSdk;
 use App\Services\SleeperSdk;
+use App\Support\PlayerInfo;
 use Illuminate\Support\Facades\App as LaravelApp;
 use OPGG\LaravelMcpServer\Services\ToolService\ToolInterface;
 
@@ -126,6 +127,17 @@ class AdpGetTool implements ToolInterface
 
             $adp = $list;
         }
+
+        // Enrich with player information
+        $players = PlayerInfo::fetch(array_column($adp, 'player_id'), $sport);
+        foreach ($adp as &$row) {
+            $pid = (string) ($row['player_id'] ?? '');
+            $info = $players[$pid] ?? ['name' => null, 'position' => null, 'team' => null];
+            $row['name'] = $info['name'];
+            $row['position'] = $info['position'];
+            $row['team'] = $info['team'];
+        }
+        unset($row);
 
         return ['season' => $season, 'format' => $format, 'adp' => $adp];
     }

--- a/app/Support/PlayerInfo.php
+++ b/app/Support/PlayerInfo.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Support;
+
+use App\Services\SleeperSdk;
+use Illuminate\Support\Facades\App as LaravelApp;
+
+class PlayerInfo
+{
+    /**
+     * Return basic player information keyed by player ID.
+     *
+     * @param  array  $playerIds  Array of player IDs
+     * @param  string $sport      Sport key, defaults to nfl
+     * @return array<string,array{name:string|null,position:?string,team:?string}>
+     */
+    public static function fetch(array $playerIds, string $sport = 'nfl'): array
+    {
+        $playerIds = array_values(array_filter(array_unique(array_map('strval', $playerIds))));
+        if (empty($playerIds)) {
+            return [];
+        }
+
+        /** @var SleeperSdk $sdk */
+        $sdk = LaravelApp::make(SleeperSdk::class);
+        $catalog = $sdk->getPlayersCatalog($sport);
+
+        $players = [];
+        foreach ($playerIds as $pid) {
+            $meta = $catalog[$pid] ?? [];
+            $players[$pid] = [
+                'name' => $meta['full_name'] ?? trim(($meta['first_name'] ?? '') . ' ' . ($meta['last_name'] ?? '')),
+                'position' => $meta['position'] ?? null,
+                'team' => $meta['team'] ?? null,
+            ];
+        }
+
+        return $players;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add PlayerInfo helper to map player IDs to name, position, and team
- enrich ADP, recommendations, data, and lineup tools with player details

## Testing
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2845a4188324ab1d7553a136cd96