### PR TITLE
Add fetch trades tool and rename matchups tool

### DIFF
--- a/app/Http/Controllers/McpActionController.php
+++ b/app/Http/Controllers/McpActionController.php
@@ -27,7 +27,8 @@ class McpActionController extends Controller
             'api.mcp.draft-picks' => \App\MCP\Tools\DraftPicksTool::class,
             'api.mcp.get-league' => \App\MCP\Tools\GetLeagueTool::class,
             'api.mcp.fetch-rosters' => \App\MCP\Tools\FetchRostersTool::class,
-            'api.mcp.get-matchups' => \App\MCP\Tools\GetMatchupsTool::class,
+            'api.mcp.fetch-matchups' => \App\MCP\Tools\FetchMatchupsTool::class,
+            'api.mcp.fetch-trades' => \App\MCP\Tools\FetchTradesTool::class,
         ];
 
         $toolClass = $routeToToolClassMap[$routeName] ?? null;
@@ -181,7 +182,8 @@ class McpActionController extends Controller
             'draft-picks',
             'get-league',
             'fetch-rosters',
-            'get-matchups',
+            'fetch-matchups',
+            'fetch-trades',
         ];
     }
 
@@ -197,7 +199,8 @@ class McpActionController extends Controller
             'draft-picks' => 'draft-picks',
             'get-league' => 'get-league',
             'fetch-rosters' => 'fetch-rosters',
-            'get-matchups' => 'get-matchups',
+            'fetch-matchups' => 'fetch-matchups',
+            'fetch-trades' => 'fetch-trades',
         ];
 
         return $mapping[$tool] ?? $tool;

--- a/app/MCP/Tools/FetchMatchupsTool.php
+++ b/app/MCP/Tools/FetchMatchupsTool.php
@@ -10,7 +10,7 @@ use OPGG\LaravelMcpServer\Exceptions\Enums\JsonRpcErrorCode;
 use OPGG\LaravelMcpServer\Exceptions\JsonRpcErrorException;
 use OPGG\LaravelMcpServer\Services\ToolService\ToolInterface;
 
-class GetMatchupsTool implements ToolInterface
+class FetchMatchupsTool implements ToolInterface
 {
     public function isStreaming(): bool
     {
@@ -19,12 +19,12 @@ class GetMatchupsTool implements ToolInterface
 
     public function name(): string
     {
-        return 'get-matchups';
+        return 'fetch-matchups';
     }
 
     public function description(): string
     {
-        return 'Get matchups for a league for a given week (defaults to current week). Optionally filter by username or user ID to return only that user\'s matchup.';
+        return 'Fetch matchups for a league for a given week (defaults to current week). Optionally filter by username or user ID to return only that user\'s matchup.';
     }
 
     public function inputSchema(): array
@@ -70,7 +70,7 @@ class GetMatchupsTool implements ToolInterface
     public function annotations(): array
     {
         return [
-            'title' => 'Get League Matchups',
+            'title' => 'Fetch League Matchups',
             'readOnlyHint' => true,
             'destructiveHint' => false,
             'idempotentHint' => true,
@@ -170,7 +170,7 @@ class GetMatchupsTool implements ToolInterface
             return (int) ($state['week'] ?? 1);
         } catch (\Exception $e) {
             // Fallback to week 1 if we can't get the current week
-            logger('GetMatchupsTool: Failed to fetch current week, defaulting to 1', [
+            logger('FetchMatchupsTool: Failed to fetch current week, defaulting to 1', [
                 'sport' => $sport,
                 'error' => $e->getMessage(),
             ]);
@@ -213,7 +213,7 @@ class GetMatchupsTool implements ToolInterface
                 return $userData['user_id'] ?? null;
             }
         } catch (\Exception $e) {
-            logger('GetMatchupsTool: Failed to resolve username to user_id', [
+            logger('FetchMatchupsTool: Failed to resolve username to user_id', [
                 'username' => $username,
                 'error' => $e->getMessage(),
             ]);
@@ -256,7 +256,7 @@ class GetMatchupsTool implements ToolInterface
                 }
             }
         } catch (\Exception $e) {
-            logger('GetMatchupsTool: Failed to filter matchups by user', [
+            logger('FetchMatchupsTool: Failed to filter matchups by user', [
                 'user_id' => $userId,
                 'league_id' => $leagueId,
                 'error' => $e->getMessage(),
@@ -370,7 +370,7 @@ class GetMatchupsTool implements ToolInterface
 
             return $enhancedMatchups;
         } catch (\Exception $e) {
-            logger('GetMatchupsTool: Failed to enhance matchups with details', [
+            logger('FetchMatchupsTool: Failed to enhance matchups with details', [
                 'league_id' => $leagueId,
                 'error' => $e->getMessage(),
             ]);

--- a/app/MCP/Tools/FetchTradesTool.php
+++ b/app/MCP/Tools/FetchTradesTool.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\MCP\Tools;
+
+use App\Http\Resources\PlayerResource;
+use App\Models\Player;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Validator;
+use OPGG\LaravelMcpServer\Exceptions\Enums\JsonRpcErrorCode;
+use OPGG\LaravelMcpServer\Exceptions\JsonRpcErrorException;
+use OPGG\LaravelMcpServer\Services\ToolService\ToolInterface;
+
+class FetchTradesTool implements ToolInterface
+{
+    public function isStreaming(): bool
+    {
+        return false;
+    }
+
+    public function name(): string
+    {
+        return 'fetch-trades';
+    }
+
+    public function description(): string
+    {
+        return 'Fetches trades for a league and returns trade details with expanded player information. Set `pending_only` to true to limit results to pending trades.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'league_id' => [
+                    'type' => 'string',
+                    'description' => 'Sleeper league ID to fetch trades for',
+                ],
+                'round' => [
+                    'anyOf' => [
+                        ['type' => 'integer', 'minimum' => 1],
+                        ['type' => 'null'],
+                    ],
+                    'description' => 'Week/round to fetch transactions for (defaults to 1)',
+                    'default' => 1,
+                ],
+                'roster_id' => [
+                    'anyOf' => [
+                        ['type' => 'integer'],
+                        ['type' => 'null'],
+                    ],
+                    'description' => 'Optional: filter trades involving this roster ID',
+                ],
+                'pending_only' => [
+                    'type' => 'boolean',
+                    'description' => 'If true, only include trades with status pending',
+                    'default' => false,
+                ],
+            ],
+            'required' => ['league_id'],
+        ];
+    }
+
+    public function annotations(): array
+    {
+        return [
+            'title' => 'Fetch League Trades',
+            'readOnlyHint' => true,
+            'destructiveHint' => false,
+            'idempotentHint' => true,
+            'openWorldHint' => true,
+            'category' => 'fantasy-sports',
+            'data_source' => 'external_api_and_database',
+            'cache_recommended' => false,
+        ];
+    }
+
+    public function execute(array $arguments): mixed
+    {
+        $validator = Validator::make($arguments, [
+            'league_id' => ['required', 'string'],
+            'round' => ['nullable', 'integer', 'min:1'],
+            'roster_id' => ['nullable', 'integer'],
+            'pending_only' => ['boolean'],
+        ]);
+
+        if ($validator->fails()) {
+            throw new JsonRpcErrorException(
+                message: 'Validation failed: '.$validator->errors()->first(),
+                code: JsonRpcErrorCode::INVALID_REQUEST
+            );
+        }
+
+        $leagueId = $arguments['league_id'];
+        $round = $arguments['round'] ?? 1;
+        $filterRoster = $arguments['roster_id'] ?? null;
+        $pendingOnly = $arguments['pending_only'] ?? false;
+
+        $response = Http::get("https://api.sleeper.app/v1/league/{$leagueId}/transactions/{$round}");
+
+        if (! $response->successful()) {
+            throw new JsonRpcErrorException(
+                message: 'Failed to fetch transactions from Sleeper API',
+                code: JsonRpcErrorCode::INTERNAL_ERROR
+            );
+        }
+
+        $transactions = $response->json();
+
+        if (! is_array($transactions)) {
+            throw new JsonRpcErrorException(
+                message: 'Invalid transaction data received from API',
+                code: JsonRpcErrorCode::INTERNAL_ERROR
+            );
+        }
+
+        $trades = array_filter($transactions, function ($tx) use ($filterRoster, $pendingOnly) {
+            if (($tx['type'] ?? null) !== 'trade') {
+                return false;
+            }
+
+            if ($pendingOnly && ($tx['status'] ?? null) !== 'pending') {
+                return false;
+            }
+
+            if ($filterRoster !== null) {
+                return in_array($filterRoster, $tx['roster_ids'] ?? []);
+            }
+
+            return true;
+        });
+
+        // Gather all player IDs to expand
+        $allPlayerIds = [];
+        foreach ($trades as $trade) {
+            if (isset($trade['adds']) && is_array($trade['adds'])) {
+                $allPlayerIds = array_merge($allPlayerIds, array_keys($trade['adds']));
+            }
+            if (isset($trade['drops']) && is_array($trade['drops'])) {
+                $allPlayerIds = array_merge($allPlayerIds, array_keys($trade['drops']));
+            }
+        }
+        $allPlayerIds = array_unique($allPlayerIds);
+
+        $playersFromDb = [];
+        if (! empty($allPlayerIds)) {
+            $playersFromDb = Player::whereIn('player_id', $allPlayerIds)
+                ->get()
+                ->mapWithKeys(fn ($p) => [
+                    $p->player_id => (new PlayerResource($p))->resolve(),
+                ])
+                ->all();
+        }
+
+        $resultTrades = [];
+        foreach ($trades as $trade) {
+            $resultTrades[] = [
+                'transaction_id' => $trade['transaction_id'] ?? null,
+                'status' => $trade['status'] ?? null,
+                'roster_ids' => $trade['roster_ids'] ?? [],
+                'adds' => $this->transformPlayers($trade['adds'] ?? [], $playersFromDb, 'to_roster_id'),
+                'drops' => $this->transformPlayers($trade['drops'] ?? [], $playersFromDb, 'from_roster_id'),
+                'draft_picks' => $trade['draft_picks'] ?? [],
+                'waiver_budget' => $trade['waiver_budget'] ?? [],
+            ];
+        }
+
+        return [
+            'success' => true,
+            'data' => array_values($resultTrades),
+            'count' => count($resultTrades),
+            'metadata' => [
+                'league_id' => $leagueId,
+                'round' => $round,
+                'filtered_roster_id' => $filterRoster,
+                'pending_only' => $pendingOnly,
+                'executed_at' => now()->toISOString(),
+            ],
+        ];
+    }
+
+    private function transformPlayers(array $playerMap, array $playersFromDb, string $rosterKey): array
+    {
+        $enhanced = [];
+        foreach ($playerMap as $playerId => $rid) {
+            $enhanced[] = [
+                'player_id' => (string) $playerId,
+                $rosterKey => $rid,
+                'player' => $playersFromDb[$playerId] ?? null,
+            ];
+        }
+
+        return $enhanced;
+    }
+}

--- a/config/mcp-server.php
+++ b/config/mcp-server.php
@@ -254,7 +254,8 @@ return [
         \App\MCP\Tools\DraftPicksTool::class,
         \App\MCP\Tools\GetLeagueTool::class,
         \App\MCP\Tools\FetchRostersTool::class,
-        \App\MCP\Tools\GetMatchupsTool::class,
+        \App\MCP\Tools\FetchMatchupsTool::class,
+        \App\MCP\Tools\FetchTradesTool::class,
 
         // ===== REGISTER YOUR CUSTOM TOOLS BELOW =====
         // App\MCP\Tools\Database\Your::class,

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -16,7 +16,8 @@ info:
     - **draft-picks**: Get intelligent draft pick recommendations
     - **get-league**: Get detailed league information and users
     - **fetch-rosters**: Get roster data for all teams in a league
-    - **get-matchups**: Get matchup data for a specific week
+    - **fetch-matchups**: Fetch matchup data for a specific week
+    - **fetch-trades**: Fetch trades in a league with player details
 
     ## Authentication
 
@@ -198,13 +199,13 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /mcp/tools/get-matchups:
+  /mcp/tools/fetch-matchups:
     post:
-      summary: Get league matchups
+      summary: Fetch league matchups
       description: |
         Fetches matchup data for a specific week in a league.
         Returns scores, projections, and matchup pairings.
-      operationId: getMatchups
+      operationId: fetchMatchups
       tags:
         - Matchup Data
       requestBody:
@@ -212,14 +213,40 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GetMatchupsRequest'
+              $ref: '#/components/schemas/FetchMatchupsRequest'
       responses:
         '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetMatchupsResponse'
+                $ref: '#/components/schemas/FetchMatchupsResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /mcp/tools/fetch-trades:
+    post:
+      summary: Fetch league trades
+      description: |
+        Fetches trades for a league and returns trade details with expanded player information. Set `pending_only` to true to limit results to pending trades.
+      operationId: fetchTrades
+      tags:
+        - Trades
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FetchTradesRequest'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FetchTradesResponse'
         '400':
           $ref: '#/components/responses/ValidationError'
         '500':
@@ -366,7 +393,7 @@ components:
       required:
         - league_id
 
-    GetMatchupsRequest:
+    FetchMatchupsRequest:
       type: object
       properties:
         league_id:
@@ -584,7 +611,7 @@ components:
               type: string
               format: date-time
 
-    GetMatchupsResponse:
+    FetchMatchupsResponse:
       type: object
       properties:
         success:
@@ -620,6 +647,117 @@ components:
               type: string
               format: date-time
 
+    FetchTradesRequest:
+      type: object
+      properties:
+        league_id:
+          type: string
+          description: Sleeper league ID to fetch trades for
+          example: "987654321"
+        round:
+          type: integer
+          description: Week/round to fetch transactions for
+          example: 1
+        roster_id:
+          type: integer
+          nullable: true
+          description: Optional roster ID to filter trades
+          example: 2
+        pending_only:
+          type: boolean
+          description: If true, only include trades with status pending
+          example: false
+      required:
+        - league_id
+
+    TradeAddedPlayer:
+      type: object
+      properties:
+        player_id:
+          type: string
+          example: "p1"
+        to_roster_id:
+          type: integer
+          example: 2
+        player:
+          $ref: '#/components/schemas/Player'
+
+    TradeDroppedPlayer:
+      type: object
+      properties:
+        player_id:
+          type: string
+          example: "p1"
+        from_roster_id:
+          type: integer
+          example: 1
+        player:
+          $ref: '#/components/schemas/Player'
+
+    TradeDetails:
+      type: object
+      properties:
+        transaction_id:
+          type: string
+          example: "1234567890"
+        status:
+          type: string
+          example: pending
+        roster_ids:
+          type: array
+          items:
+            type: integer
+        adds:
+          type: array
+          items:
+            $ref: '#/components/schemas/TradeAddedPlayer'
+        drops:
+          type: array
+          items:
+            $ref: '#/components/schemas/TradeDroppedPlayer'
+        draft_picks:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        waiver_budget:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+
+    FetchTradesResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/TradeDetails'
+        count:
+          type: integer
+          example: 1
+        metadata:
+          type: object
+          properties:
+            league_id:
+              type: string
+              example: "987654321"
+            round:
+              type: integer
+              example: 1
+            filtered_roster_id:
+              type: integer
+              nullable: true
+              example: 2
+            pending_only:
+              type: boolean
+              example: false
+            executed_at:
+              type: string
+              format: date-time
     Player:
       type: object
       properties:

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,12 +21,14 @@ Route::post('/mcp/tools/get-league', [McpActionController::class, 'invokeTool'])
     ->name('api.mcp.get-league');
 Route::post('/mcp/tools/fetch-rosters', [McpActionController::class, 'invokeTool'])
     ->name('api.mcp.fetch-rosters');
-Route::post('/mcp/tools/get-matchups', [McpActionController::class, 'invokeTool'])
-    ->name('api.mcp.get-matchups');
+Route::post('/mcp/tools/fetch-matchups', [McpActionController::class, 'invokeTool'])
+    ->name('api.mcp.fetch-matchups');
+Route::post('/mcp/tools/fetch-trades', [McpActionController::class, 'invokeTool'])
+    ->name('api.mcp.fetch-trades');
 
 // Legacy generic endpoint for backward compatibility
 Route::post('/mcp/tools/{tool}', [McpActionController::class, 'invoke'])
-    ->where('tool', 'fetch-trending-players|fetch-adp-players|fetch-user-leagues|draft-picks|get-league|fetch-rosters|get-matchups')
+    ->where('tool', 'fetch-trending-players|fetch-adp-players|fetch-user-leagues|draft-picks|get-league|fetch-rosters|fetch-matchups|fetch-trades')
     ->name('api.mcp.invoke');
 
 Route::get('/openapi.yaml', function () {
@@ -53,7 +55,8 @@ Route::get('/mcp/tools', function () {
         'draft-picks',
         'get-league',
         'fetch-rosters',
-        'get-matchups',
+        'fetch-matchups',
+        'fetch-trades',
     ];
 
     return response()->json([
@@ -67,7 +70,8 @@ Route::get('/mcp/tools', function () {
                     'draft-picks' => 'Provides intelligent draft pick suggestions by analyzing draft state and player ADP values',
                     'get-league' => 'Get league information and users for a specific league',
                     'fetch-rosters' => 'Fetches rosters for all users in a league',
-                    'get-matchups' => 'Fetches matchups and scores for a league in a specific week',
+                    'fetch-matchups' => 'Fetches matchups and scores for a league in a specific week',
+                    'fetch-trades' => 'Fetches trades in a league with expanded player details',
                 },
                 'endpoint' => "/api/mcp/tools/{$tool}",
                 'method' => 'POST',

--- a/tests/Feature/FetchMatchupsToolTest.php
+++ b/tests/Feature/FetchMatchupsToolTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\MCP\Tools\GetMatchupsTool;
+use App\MCP\Tools\FetchMatchupsTool;
 use App\Models\Player;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
@@ -11,13 +11,13 @@ use OPGG\LaravelMcpServer\Exceptions\JsonRpcErrorException;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    $this->tool = new GetMatchupsTool;
+    $this->tool = new FetchMatchupsTool;
 });
 
 it('has correct tool properties', function () {
-    expect($this->tool->name())->toBe('get-matchups');
+    expect($this->tool->name())->toBe('fetch-matchups');
     expect($this->tool->isStreaming())->toBeFalse();
-    expect($this->tool->description())->toContain('Get matchups for a league');
+    expect($this->tool->description())->toContain('Fetch matchups for a league');
 });
 
 it('validates required fields', function () {
@@ -303,7 +303,7 @@ it('has correct input schema', function () {
 it('has correct annotations', function () {
     $annotations = $this->tool->annotations();
 
-    expect($annotations['title'])->toBe('Get League Matchups');
+    expect($annotations['title'])->toBe('Fetch League Matchups');
     expect($annotations['readOnlyHint'])->toBeTrue();
     expect($annotations['destructiveHint'])->toBeFalse();
     expect($annotations['idempotentHint'])->toBeTrue();

--- a/tests/Feature/FetchTradesToolTest.php
+++ b/tests/Feature/FetchTradesToolTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use App\MCP\Tools\FetchTradesTool;
+use App\Models\Player;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use OPGG\LaravelMcpServer\Exceptions\JsonRpcErrorException;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->tool = new FetchTradesTool();
+});
+
+it('has correct tool properties', function () {
+    expect($this->tool->name())->toBe('fetch-trades');
+    expect($this->tool->isStreaming())->toBeFalse();
+    expect($this->tool->description())->toContain('trades');
+});
+
+it('validates required fields', function () {
+    expect(fn () => $this->tool->execute([]))
+        ->toThrow(JsonRpcErrorException::class, 'Validation failed');
+});
+
+it('handles API failure gracefully', function () {
+    Http::fake([
+        '*' => Http::response(null, 500),
+    ]);
+
+    expect(fn () => $this->tool->execute([
+        'league_id' => 'league_123',
+    ]))->toThrow(JsonRpcErrorException::class);
+});
+
+it('returns trades with expanded player details and filters pending when requested', function () {
+    Player::factory()->create([
+        'player_id' => 'p1',
+        'full_name' => 'Player One',
+        'position' => 'QB',
+        'team' => 'BUF',
+    ]);
+
+    Player::factory()->create([
+        'player_id' => 'p2',
+        'full_name' => 'Player Two',
+        'position' => 'WR',
+        'team' => 'KC',
+    ]);
+
+    Http::fake([
+        'https://api.sleeper.app/v1/league/league_123/transactions/1' => Http::response([
+            [
+                'type' => 'trade',
+                'transaction_id' => 'tx1',
+                'status' => 'pending',
+                'roster_ids' => [1, 2],
+                'adds' => [
+                    'p1' => 2,
+                    'p2' => 1,
+                ],
+                'drops' => [
+                    'p1' => 1,
+                    'p2' => 2,
+                ],
+                'draft_picks' => [],
+                'waiver_budget' => [],
+            ],
+            [
+                'type' => 'trade',
+                'transaction_id' => 'tx2',
+                'status' => 'complete',
+                'roster_ids' => [3, 4],
+                'adds' => [],
+                'drops' => [],
+                'draft_picks' => [],
+                'waiver_budget' => [],
+            ],
+        ]),
+    ]);
+
+    $result = $this->tool->execute([
+        'league_id' => 'league_123',
+        'round' => 1,
+    ]);
+
+    expect($result['success'])->toBeTrue();
+    expect($result['count'])->toBe(2);
+
+    $trade = collect($result['data'])->firstWhere('transaction_id', 'tx1');
+    expect($trade['adds'])->toHaveCount(2);
+
+    $addP1 = collect($trade['adds'])->firstWhere('player_id', 'p1');
+    expect($addP1['player']['full_name'])->toBe('Player One');
+    expect($addP1['to_roster_id'])->toBe(2);
+
+    $dropP2 = collect($trade['drops'])->firstWhere('player_id', 'p2');
+    expect($dropP2['player']['full_name'])->toBe('Player Two');
+    expect($dropP2['from_roster_id'])->toBe(2);
+
+    $pendingResult = $this->tool->execute([
+        'league_id' => 'league_123',
+        'round' => 1,
+        'pending_only' => true,
+    ]);
+
+    expect($pendingResult['count'])->toBe(1);
+    expect($pendingResult['data'][0]['transaction_id'])->toBe('tx1');
+});


### PR DESCRIPTION
## Summary
- refactor trade review into `FetchTradesTool` with optional `pending_only` filter
- rename `get-matchups` MCP tool to `fetch-matchups` across controllers, routes, and documentation

## Testing
- `php artisan test tests/Feature/FetchTradesToolTest.php`
- `php artisan test tests/Feature/FetchMatchupsToolTest.php` *(fails: missing `.env` file and HTTP 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c6acfe308324974a8170997cfbda