### PR TITLE
Fix text wrapping on welcome page

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,6 +1,6 @@
 
 <x-layouts.app.marketing>
-    <div class="min-h-screen bg-[#FDFDFC] dark:bg-[#0a0a0a] text-[#1b1b18] dark:text-[#EDEDEC] px-4 sm:px-6 py-8 sm:py-12">
+    <div class="min-h-screen bg-[#FDFDFC] dark:bg-[#0a0a0a] text-[#1b1b18] dark:text-[#EDEDEC] px-4 sm:px-6 py-8 sm:py-12 break-words">
         <div class="mx-auto max-w-6xl">
             <header class="mb-6 flex justify-end">
                 @if (Route::has('login'))


### PR DESCRIPTION
## Summary
- ensure long text on the welcome page wraps and doesn't cause horizontal scroll on mobile

## Testing
- `composer test` *(fails: Failed to fetch user leagues from Sleeper API)*

------
https://chatgpt.com/codex/tasks/task_e_68b60867de448324b1032ad2ffbecdea